### PR TITLE
Rework in_silico_pcr to be memory efficient on large inputs

### DIFF
--- a/crabs
+++ b/crabs
@@ -3,7 +3,7 @@
 ##################
 # IMPORT MODULES #
 ##################
-import os, rich, rich.progress, collections, requests
+import os, rich, rich.progress, collections, requests, shutil
 import rich_click as click
 from function import __version__
 from function.crabs_functions import (check_params,
@@ -44,7 +44,7 @@ from function.crabs_functions import (check_params,
                                       cutadapt,
                                       cutadapt_relaxed,
                                       crabs_to_fasta,
-                                      list_to_fasta,
+                                      fasta_to_crabs,
                                       multiple_crabs_to_fasta,
                                       multiple_list_to_temp,
                                       usearch_global,
@@ -890,25 +890,25 @@ def crabs(**kwargs):
         overlap = str(min(len(forward_), len(reverse_)))
         adapter = forward_ + '...' + reverse_
         # transform input_ to fasta format in a temp file
-        temp_input_path, fasta_dict = crabs_to_fasta(console, columns, input_)
-        # run cutadapt
-        trimmed_seqs, untrimmed_seqs = cutadapt(console, columns, adapter, temp_input_path, fasta_dict, mismatch_, overlap, threads_, buffer_size_)
+        temp_input_path, nseq = crabs_to_fasta(console, columns, input_)
+        # run cutadapt - outputs are Tempfiles paths and counters
+        trimmed_seqs, untrimmed_seqs, ntrim, nuntrim = cutadapt(console, columns, adapter, temp_input_path, nseq, mismatch_, overlap, threads_, buffer_size_)
         # run cutadapt again if the relaxed_ parameter was provided
         if relaxed_:
-            temp_input_path2, fasta_dict2 = list_to_fasta(console, columns, untrimmed_seqs)
-            trimmed_seqs, untrimmed_seqs, relaxed_count = cutadapt_relaxed(console, columns, forward_, reverse_, temp_input_path2, fasta_dict2, mismatch_, overlap, threads_, trimmed_seqs, untrimmed_seqs, buffer_size_)
-        # write data to output
-        write_list_to_output(console, columns, trimmed_seqs, output_)
+            trimmed_seqs, untrimmed_seqs, relaxed_count, untrim_count = cutadapt_relaxed(console, columns, forward_, reverse_, untrimmed_seqs, nuntrim, mismatch_, overlap, threads_, trimmed_seqs, buffer_size_)
+        # move temp file to output location - no rich progress bar but it should be very fast except if moving to another file system
+        shutil.move(trimmed_seqs, output_)
         if untrimmed_:
-            write_list_to_output(console, columns, untrimmed_seqs, untrimmed_)
+            untrimmed_crabs, _ = fasta_to_crabs(console, columns, untrimmed_seqs)
+            shutil.move(untrimmed_crabs, untrimmed_)
         # remove temporary files
+        os.remove(untrimmed_seqs)
         os.remove(temp_input_path)
-        if relaxed_:
-            os.remove(temp_input_path2)
         # write log to Terminal window
-        console.print(f"[cyan]|             Results[/] | Extracted {len(trimmed_seqs)} amplicons from {len(fasta_dict)} sequences ({round(len(trimmed_seqs) / len(fasta_dict) * 100, 2)}%)")
+        ## TODO fix sequence file count
+        console.print(f"[cyan]|             Results[/] | Extracted {ntrim} amplicons from {nseq} sequences ({round(ntrim / nseq * 100, 2)}%)")
         if relaxed_:
-            console.print(f"[cyan]|             Results[/] | {relaxed_count} amplicons were extracted by only the forward or reverse primer ({round(relaxed_count / len(trimmed_seqs) * 100, 2)}%)")
+            console.print(f"[cyan]|             Results[/] | {relaxed_count} amplicons were extracted by only the forward or reverse primer ({round(relaxed_count / nseq * 100, 2)}%)")
 
 #############################
 # PAIRWISE GLOBAL ALIGNMENT #


### PR DESCRIPTION
# What this PR adresses:

As explained in #115, the `in_silico_pcr` function uses a lot of memory which can lead to processes being automatically killed for large inputs, even on very large systems.

This is currently due to the following:

- `crabs_to_fasta`  loads the netire crabs file twice in memory as `fasta_dict` and `fasta_list`
- `cutadapt` and `cutadapt_relaxed` load the entire untrimmed sequences and trimmed sequences in memory as `trimmed_seqs` and `untrimmed_seqs`

In worst case scenario (using `--relaxed` with very little sequences being trimmed) the input file is loaded 4 times in memory.

Instead of loading large datasets in memory, they should be streamed directly to (temporary-) files.

# List of changes

## Dependencies

Added `shutil` (standard library) as a dependency to allow for robust moving of tempfiles to output locations across filesystems.

## `crabs_to_fasta`

Now reads input crabs file line by line and write each line to a fasta file direclty. 
Only loads a single line in memory at a time.
Outputs the number of sequences as an integer counter for tracking instead of a list.

## `cutadapt`

Cutadapt now write untrimmed reads directly to a tempfile. 
Trimmed reads are still loaded in memory by cutadapt but are writtten to another tempfile instead of stying in memory as a list.
Lists of trimmed and untrimmed sequences are replaced by integer counters for tracking.

## `cutadapt_relaxed`

Same as above. Trimmed reads are merged with those of the `cutadapt` function and untrimmed reads correctly outputed to a temp files

## Main function

Required tempfiles are moved to their parametrized locations using `shutil.move`, other tempfiles are removed.
Number of trimmed sequences is reported using integer counters form the individual functions.

## `list_to_fasta`

Since no data is passed between functions as list, this became unnescessary and was removed.

# Performance checks

Comparisons were done using a ~ 42 Gb crabs file contianing all core_nt sequences corresponding to the Spermatophyta clade

## Before changes:

```
|            Function | Extract amplicons through in silico PCR
|         Import data | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 0:08:51
|  Transform to fasta | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 0:01:54
|       In silico PCR | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0:02:32Killed
```

RAM usage reached >90Gb of 92Gb available and the porcess was killed

## After changes

```
|            Function | Extract amplicons through in silico PCR
|     Import to fasta | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 0:02:39
|       In silico PCR | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 0:02:55
|             Results | Extracted 3276 amplicons from 13432321 sequences (0.02%)
```

RAM usage peaks at about 3-4Gb, corresponding to the trimmed sequences being loaded inmemory by cutadapt, this could be reduced by directing them to a tempfile too, howver in most cases trimmed sequences should be fairly small in comparison to the dataset. 
This does however require storage space on the file system for twice the size of the input file (once for conversion to fasta and once for storing the trimmed and untrimmed sequences).

Processing speed of the input is also considerably reduced by streaming the crabs file directly to fasta.

## After changes, relaxed processing

```
|            Function | Extract amplicons through in silico PCR
|     Import to fasta | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 0:02:34
|       In silico PCR | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 0:03:26
|      relaxed IS PCR | ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:-- 0:05:11
|             Results | Extracted 3276 amplicons from 13432321 sequences (0.02%)
|             Results | 333637 amplicons were extracted by only the forward or reverse primer (2.48%)
```

Same as above

# Caveats

- While considerably reducing the RAM footprint of the function, this transfers some of this requirements to the filesystem.
- Since cutadapt writes most data to a file and counting line is so slow in pYthon, progress bars do not update in real time but are simply filled to 100% when cutadapt is done

Let me know your thoughts and it and if something should be changed!
Cheers 
Greg